### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 1.5.0
  February 29, 2020
 - CupertinoApp, showAboutDialog(), foundation.dart' show kIsWeb;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mvc_application
 description: Flutter Framework for Applications using the MVC Design Pattern
-version: 1.5.0
+version: 1.5.1
 author: Greg Perry <support@andrioussolutions.com>
 homepage: https://github.com/AndriousSolutions/mvc_application
 repository: https://github.com/AndriousSolutions/mvc_application
@@ -20,7 +20,7 @@ dependencies:
   url_launcher: ^5.0.0
 
   # https://pub.dartlang.org/packages/package_info#-changelog-tab-
-  package_info: ^0.4.0
+  package_info: '>=0.4.0 <2.0.0'
 
   # https://pub.dartlang.org/packages/device_info#-changelog-tab-
   device_info: ^0.4.0


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).